### PR TITLE
Make sure prompts are dynamic.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -21,3 +21,4 @@ exclude_patterns:
   - 'bin/'
   - 'test/'
   - 'assets/javascripts/nest/modal.js' # 3rd party library
+  - 'assets/javascripts/nest/utils/dynamicListener.js' # 3rd party library

--- a/assets/javascripts/nest/rails.js
+++ b/assets/javascripts/nest/rails.js
@@ -1,26 +1,28 @@
+//= require ./utils/dynamicListener
+
 document.addEventListener('turbolinks:load', () => {
-  const elements = document.querySelectorAll('[data-prompt]');
+  let confirmed = false;
 
-  elements.forEach(element => {
-    let confirmed = false;
+  addDynamicEventListener(document.body, 'click', '[data-prompt]', handleClick);
 
-    element.addEventListener('click', event => {
-      if (confirmed) return;
+  function handleClick(event) {
+    if (confirmed) {
+      confirmed = false;
+      return;
+    }
 
-      Rails.stopEverything(event);
+    Rails.stopEverything(event);
 
-      const finalEvent = event;
-      const target = event.currentTarget;
+    const target = event.target;
 
-      new Toast({
-        message: target.getAttribute('data-prompt'),
-        type: 'danger',
-        action: 'OK',
-        onClick: () => {
-          confirmed = true;
-          target.click();
-        }
-      });
+    new Toast({
+      message: target.getAttribute('data-prompt'),
+      type: 'danger',
+      action: 'OK',
+      onClick: () => {
+        confirmed = true;
+        target.click({ something: 'hello' });
+      }
     });
-  });
+  }
 });

--- a/assets/javascripts/nest/utils/dynamicListener.js
+++ b/assets/javascripts/nest/utils/dynamicListener.js
@@ -1,0 +1,80 @@
+// Credits
+// https://github.com/Cristy94/dynamic-listener
+//
+// Usage
+//
+// addDynamicEventListener(document.body, 'click', '[data-prompt]', event => {
+//   console.log(event);
+// });
+(function(globalSope) {
+  'use strict';
+
+  /**
+     * Including this file adds the `addDynamicListener` to the ELement prototype.
+     *
+     * The dynamic listener gets an extra `selector` parameter that only calls the callback
+     * if the target element matches the selector.
+     *
+     * The listener has to be added to the container/root element and the selector should match
+     * the elements that should trigger the event.
+     *
+     * Browser support: IE9+
+     */
+
+  // Polyfil Element.matches
+  // https://developer.mozilla.org/en/docs/Web/API/Element/matches#Polyfill
+  if (!Element.prototype.matches) {
+    Element.prototype.matches =
+      Element.prototype.matchesSelector ||
+      Element.prototype.mozMatchesSelector ||
+      Element.prototype.msMatchesSelector ||
+      Element.prototype.oMatchesSelector ||
+      Element.prototype.webkitMatchesSelector ||
+      function(s) {
+        var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+          i = matches.length;
+        while (--i >= 0 && matches.item(i) !== this) {}
+        return i > -1;
+      };
+  }
+
+  /**
+     * Returns a modified callback function that calls the
+     * initial callback function only if the target element matches the given selector
+     *
+     * @param {string} selector
+     * @param {function} callback
+     */
+  function getConditionalCallback(selector, callback) {
+    return function(e) {
+      if (!e.target) return;
+      if (!e.target.matches(selector)) return;
+      callback.apply(this, arguments);
+    };
+  }
+
+  /**
+     *
+     *
+     * @param {Element} rootElement The root element to add the linster too.
+     * @param {string} eventType The event type to listen for.
+     * @param {string} selector The selector that should match the dynamic elements.
+     * @param {function} callback The function to call when an event occurs on the given selector.
+     * @param {boolean|object} options Passed as the regular `options` parameter to the addEventListener function
+     *                                 Set to `true` to use capture.
+     *                                 Usually used as an object to add the listener as `passive`
+     */
+  globalSope.addDynamicEventListener = function(
+    rootElement,
+    eventType,
+    selector,
+    callback,
+    options
+  ) {
+    rootElement.addEventListener(
+      eventType,
+      getConditionalCallback(selector, callback),
+      options
+    );
+  };
+})(this);

--- a/assets/stylesheets/nest/utils/_typography.scss
+++ b/assets/stylesheets/nest/utils/_typography.scss
@@ -7,6 +7,14 @@
 }
 
 //
+// Pointers
+//
+
+.pointerless {
+  pointer-events: none;
+}
+
+//
 // Horizontal rules
 //
 


### PR DESCRIPTION
Right now, when elements are appended to the DOM after load that contain
the data-prompt attribute, they won't be recognized. This PR addresses
that, and makes sure those dynamic elements are recognized.